### PR TITLE
Adding Debezium

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,36 @@ $ docker run --tty --rm -i \
     bash -c 'mycli mysql://mysqluser@mysql:3306/orderweb --password mysqlpw'
 ```
 
+Listing all topics in Kafka:
+
+```
+$ docker-compose exec kafka /kafka/bin/kafka-topics.sh --zookeeper zookeeper:2181 --list
+```
+
+Reading contents of "order" topic:
+
+```
+$ docker run --tty --rm \
+    --network PinotNetwork \
+    debezium/tooling:1.1 \
+    kafkacat -b kafka:9092 -C -o beginning -q \
+    -t order
+```
+
+Registering Debezium MySQL connector:
+
+```
+$ curl -i -X PUT -H "Accept:application/json" -H  "Content-Type:application/json" \
+    http://localhost:8083/connectors/orderweb/config -d @debezium-mysql-connector.json
+```
+
+Getting status of "orderweb" connector:
+
+```
+$ curl -i -X GET -H "Accept:application/json" -H  "Content-Type:application/json" \
+    http://localhost:8083/connectors/orderweb/status
+```
+
 ## License
 
 This project is an open source product licensed under Apache License v2.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,24 @@ API usage information for the `order-web` service can be found [here](order/READ
   - Show current deliveries by restaurant id
   - Show current deliveries by restaurant city
 
-# License
+## Build
+
+```bash
+$ mvn clean verify -DskipTests=true
+$ docker-compose up
+```
+
+## Useful Commands
+
+Getting a shell in MySQL:
+
+```
+$ docker run --tty --rm -i \
+    --network PinotNetwork \
+    debezium/tooling:1.1 \
+    bash -c 'mycli mysql://mysqluser@mysql:3306/orderweb --password mysqlpw'
+```
+
+## License
 
 This project is an open source product licensed under Apache License v2.

--- a/debezium-mysql-connector.json
+++ b/debezium-mysql-connector.json
@@ -1,0 +1,13 @@
+{
+    "connector.class": "io.debezium.connector.mysql.MySqlConnector",
+    "tasks.max": "1",
+    "database.hostname": "mysql",
+    "database.port": "3306",
+    "database.user": "debezium",
+    "database.password": "dbz",
+    "database.server.id": "184054",
+    "database.server.name": "dbserver1",
+    "database.include": "orderweb",
+    "database.history.kafka.bootstrap.servers": "kafka:9092",
+    "database.history.kafka.topic": "schema-changes.inventory"
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,16 +76,16 @@ services:
     networks:
       - PinotNetwork
   mysql:
-    image: mysql:5.7
+    image: debezium/example-mysql:1.5
     ports:
-      - "3306:3306"
-    restart: always
+      - 3306:3306
     environment:
-      MYSQL_DATABASE: bootdb
-      MYSQL_PASSWORD: root
-      MYSQL_ROOT_PASSWORD: root
+      - MYSQL_ROOT_PASSWORD=debezium
+      - MYSQL_USER=mysqluser
+      - MYSQL_PASSWORD=mysqlpw
     volumes:
-      - db_data:/var/lib/mysql
+#     - db_data:/var/lib/mysql
+      - ./mysql_init.sql:/docker-entrypoint-initdb.d/mysql_init.sql
     networks:
       - PinotNetwork
 #  postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,28 +51,38 @@ services:
     volumes: *superset-volumes
     networks:
       - PinotNetwork
-  kafka:
-    environment:
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092
-      KAFKA_BROKER_ID: 1
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:32181
-    image: confluentinc/cp-kafka:latest
+  zookeeper:
+    image: debezium/zookeeper:1.5
     ports:
-      - "29092:29092/tcp"
-    deploy:
-      replicas: 1
+      - 2181:2181
+      - 2888:2888
+      - 3888:3888
     networks:
       - PinotNetwork
-  zookeeper:
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 32181
-      ZOOKEEPER_TICK_TIME: 2000
-    image: confluentinc/cp-zookeeper:latest
+  kafka:
+    image: debezium/kafka:1.5
     ports:
-      - "32181:32181/tcp"
-    deploy:
-      replicas: 1
+      - 9092:9092
+    links:
+      - zookeeper
+    environment:
+      - ADVERTISED_HOST_NAME=192.168.178.28
+      - ZOOKEEPER_CONNECT=zookeeper:2181
+    networks:
+      - PinotNetwork
+  connect:
+    image: debezium/connect:1.5
+    ports:
+      - 8083:8083
+    links:
+      - kafka
+      - mysql
+    environment:
+      - BOOTSTRAP_SERVERS=kafka:9092
+      - GROUP_ID=1
+      - CONFIG_STORAGE_TOPIC=my_connect_configs
+      - OFFSET_STORAGE_TOPIC=my_connect_offsets
+      - STATUS_STORAGE_TOPIC=my_connect_statuses
     networks:
       - PinotNetwork
   mysql:

--- a/mysql_init.sql
+++ b/mysql_init.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE orderweb;
+GRANT ALL PRIVILEGES ON orderweb.* TO 'mysqluser'@'%';

--- a/order/order-web/src/main/resources/application.yml
+++ b/order/order-web/src/main/resources/application.yml
@@ -30,7 +30,7 @@ spring:
     stream:
       kafka:
         binder:
-          brokers: "PLAINTEXT://kafka:29092"
+          brokers: "PLAINTEXT://kafka:9092"
   jpa:
     show_sql: false
     database: H2
@@ -47,7 +47,7 @@ spring:
     stream:
       kafka:
         binder:
-          brokers: "PLAINTEXT://kafka:29092"
+          brokers: "PLAINTEXT://kafka:9092"
   datasource:
     hikari:
       maximum-pool-size: 100

--- a/order/order-web/src/main/resources/application.yml
+++ b/order/order-web/src/main/resources/application.yml
@@ -50,16 +50,16 @@ spring:
           brokers: "PLAINTEXT://kafka:29092"
   datasource:
     hikari:
-      maximum-pool-size: 10000
+      maximum-pool-size: 100
     platform: mysql
-    url: jdbc:mysql://mysql:3306/bootdb
-    username: root
-    password: root
+    url: jdbc:mysql://mysql:3306/orderweb
+    username: mysqluser
+    password: mysqlpw
     initialization-mode: always
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: false
+    show-sql: true
     generate-ddl: true
 ---
 spring:


### PR DESCRIPTION
Hey @kbastani, as discussed here's a PR for adding Debezium to the demo. This currently captures _all_ the tables from the orderweb application, whereas eventually, it should only capture the outbox table.

Are you going to change the application so that it writes the events into such table, instead of directly writing to Kafka? If so, I then could update the Debezium configuration, so to read from that outbox table exclusively. Ideally, the outbox table would have a schema as [described here](https://debezium.io/documentation/reference/configuration/outbox-event-router.html#basic-outbox-table). Then the outbox routing SMT in Debezium could pretty much be used as-is. No problem if not though (if you prefer other column names for instance), just let me know and I can configure things as needed.