### PR TITLE
WIP Adding outbox connector

### DIFF
--- a/debezium-mysql-connector-outbox.json
+++ b/debezium-mysql-connector-outbox.json
@@ -1,0 +1,21 @@
+{
+    "connector.class": "io.debezium.connector.mysql.MySqlConnector",
+    "tasks.max": "1",
+    "database.hostname": "mysql",
+    "database.port": "3306",
+    "database.user": "root",
+    "database.password": "debezium",
+    "database.server.id": "184054",
+    "database.server.name": "dbserver1",
+    "database.history.kafka.bootstrap.servers": "kafka:9092",
+    "database.history.kafka.topic": "schema-changes.order-events",
+    "table.include.list": "orderweb.order_event",
+    "transforms" : "outbox",
+    "transforms.outbox.type" : "io.debezium.transforms.outbox.EventRouter",
+    "transforms.outbox.table.field.event.key" : "aggregate_id",
+    "transforms.outbox.table.field.event.id" : "event_id",
+    "transforms.outbox.table.field.event.payload" : "order_payload",
+    "transforms.outbox.table.field.event.payload.id" : "aggregate_id",
+    "transforms.outbox.route.by.field" : "aggregate_type",
+    "value.converter.schemas.enable": "false"
+}

--- a/order/order-web/src/main/java/demo/order/event/OrderEvent.java
+++ b/order/order-web/src/main/java/demo/order/event/OrderEvent.java
@@ -1,15 +1,22 @@
 package demo.order.event;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import demo.event.Event;
-import demo.order.controller.OrderController;
-import demo.order.domain.Order;
-import demo.order.domain.OrderStatus;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Lob;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.annotation.CreatedDate;
@@ -17,10 +24,17 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.hateoas.Link;
 
-import javax.persistence.*;
-import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import demo.event.Event;
+import demo.order.controller.OrderController;
+import demo.order.domain.Order;
+import demo.order.domain.OrderStatus;
 
 /**
  * The domain event {@link OrderEvent} tracks the type and state of events as applied to the {@link Order} domain
@@ -53,6 +67,8 @@ public class OrderEvent extends Event<Order, OrderEventType, Long> {
     private OrderStatus orderStatus;
 
     private Long aggregateId;
+
+    private String aggregateType = "Order";
 
     @Column
     private Double orderLocationLat;
@@ -175,6 +191,14 @@ public class OrderEvent extends Event<Order, OrderEventType, Long> {
     @Override
     public void setAggregateId(Long aggregateId) {
         this.aggregateId = aggregateId;
+    }
+
+    public String getAggregateType() {
+        return aggregateType;
+    }
+
+    public void setAggregateType(String aggregateType) {
+        this.aggregateType = aggregateType;
     }
 
     public Double getOrderLocationLat() {


### PR DESCRIPTION
Hey @kbastani, some WIP here. I still need to look into "un-stringifying" this, but I'm blocked by https://github.com/kbastani/order-delivery-microservice-example/issues/4; the order service is mostly unresponsive and requests to place an order will time out. Eventually, the service dies with OOME. I'm not sure what it's doing 🤔 . Some notes on the current status:

* Messages are sent to the _outbox.event.Order_ topic atm., but we can adjust that (the `Order` suffix is the value of a new `aggregate_type` column I added); any other preferences for the prefix? Could also just be `Order`, if you want.
* The current structure is like this:

```
{"schema":{"type":"string","optional":true},"payload":"{\"createdAt\":1624632622667,\"lastModified\":1624632622667,\"status\":\"ORDER_CREATED\",\"accountId\":1234,\"links\":[],\"orderId\":53}"}
```

I'll remove the schema part, making it that:

```
"{\"createdAt\":1624632622667,\"lastModified\":1624632622667,\"status\":\"ORDER_CREATED\",\"accountId\":1234,\"links\":[],\"orderId\":53}"
```

Finally, I'll unstringify it, making it that:

```
{ "createdAt" : 1624632622667, "lastModified" : 1624632622667, "status" : "ORDER_CREATED", "accountId" : 1234, "links":[], "orderId":53}
```