### PR TITLE
add statement to initially create db_data volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Running the example in normal mode requires at least 16GB of system memory and i
 
 ```bash
 $ docker-compose -f docker-compose-light.yml down
+$ docker volume create --name=db_data
 $ docker-compose -f docker-compose.yml up -d
 $ docker-compose -f docker-compose.yml logs -f --tail 100 load-simulator
 ```


### PR DESCRIPTION
When running the heavy mode from scratch, compose immediately complains about missing (external) volume "db_data".
The Readme can be extended to add this step.